### PR TITLE
Added a silly loading animation to blog post loading.

### DIFF
--- a/src/blog/Post.js
+++ b/src/blog/Post.js
@@ -11,7 +11,7 @@ import * as colors from '../theme/colors';
 export default function BlogPost() {
   // Get the ID from the URL Parameter
   const { slug } = useParams();
-  const [post, setPost] = useState([]);
+  const [post, setPost] = useState(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -173,8 +173,40 @@ export default function BlogPost() {
     );
   }
   return (
+    // A silly loading animation
     <div>
-      <p>Loading...</p>
+      <h3
+        css={{
+          textAlign: 'center',
+          animation: 'pulse 1s ease-in-out 0s alternate infinite',
+          '@keyframes pulse': {
+            '0%': {
+              transform: 'scale(0.95)',
+            },
+            '100%': {
+              transform: 'scale(1.05)',
+            },
+          },
+        }}
+      >
+        Loading...
+      </h3>
+      <h3
+        css={{
+          textAlign: 'center',
+          animation: 'rollaround 3s ease-in-out 0s alternate infinite',
+          '@keyframes rollaround': {
+            '0%': {
+              transform: 'translate(-100px) rotate(-720deg)',
+            },
+            '100%': {
+              transform: 'translate(100px) rotate(720deg)',
+            },
+          },
+        }}
+      >
+        🤠
+      </h3>
     </div>
   );
 }

--- a/src/demos/CSSAnimation.js
+++ b/src/demos/CSSAnimation.js
@@ -1,0 +1,42 @@
+/* eslint-disable jsx-a11y/accessible-emoji */
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+export default function LoadingAnimation() {
+  return (
+    <div>
+      <h3
+        css={{
+          textAlign: 'center',
+          animation: 'pulse 1s ease-in-out 0s alternate infinite',
+          '@keyframes pulse': {
+            '0%': {
+              transform: 'scale(0.95)',
+            },
+            '100%': {
+              transform: 'scale(1.05)',
+            },
+          },
+        }}
+      >
+        Loading...
+      </h3>
+      <h3
+        css={{
+          textAlign: 'center',
+          animation: 'rollaround 3s ease-in-out 0s alternate infinite',
+          '@keyframes rollaround': {
+            '0%': {
+              transform: 'translate(-100px) rotate(-720deg)',
+            },
+            '100%': {
+              transform: 'translate(100px) rotate(720deg)',
+            },
+          },
+        }}
+      >
+        🤠
+      </h3>
+    </div>
+  );
+}

--- a/src/demos/Demos.js
+++ b/src/demos/Demos.js
@@ -4,6 +4,7 @@
 import { jsx } from '@emotion/core';
 import MoveableDemo from './DraggableElement';
 import Life from './Life';
+import LoadingAnimation from './CSSAnimation';
 import * as COLORS from '../theme/colors';
 
 export default function Demos() {
@@ -18,10 +19,15 @@ export default function Demos() {
       <div
         css={{
           background: COLORS.veryVeryLight,
+          padding: '1rem',
         }}
       >
-        <Life />
+        <h3>
+          Silly loading animation
+        </h3>
+        <LoadingAnimation />
       </div>
+      <Life />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
In production, loading a post actually takes time. I noticed when making the date changes that the loading screen was actually broken and tried to display the undefined date while loading the post.

This change adds a cute little loading animation. The GIF has reduced frames - the real thing is smooth and faster.

I also added the loading animation to Demos since it's cute and you don't get to see it much.

## Before
![image](https://user-images.githubusercontent.com/6733176/86495520-bc6fe980-bd47-11ea-86d6-703ab9ff2a71.png)

## After
![Screen Recording 2020-07-03 at 3 12 42 PM](https://user-images.githubusercontent.com/6733176/86495755-a44c9a00-bd48-11ea-9a17-86a75b23bdda.gif)
